### PR TITLE
Added setting different dm and server welcome messages

### DIFF
--- a/chat-bot/plugins/welcome.py
+++ b/chat-bot/plugins/welcome.py
@@ -12,29 +12,40 @@ class Welcome(Plugin):
     async def on_member_join(self, member):
         server = member.server
         storage = await self.get_storage(server)
-        welcome_message = await storage.get('welcome_message')
-        welcome_message = welcome_message.replace(
-            "{server}",
-            server.name
-        ).replace(
-            "{user}",
-            member.mention
-        )
-        channel_name = await storage.get('channel_name')
-
-        private = await storage.get('private')
-        print(private)
-        if private:
-            destination = member
-        else:
+        
+        # Send server welcome if enabled
+        server_welcome_enabled = await storage.get('server_welcome_disabled') is None
+        if server_welcome_enabled:
+            welcome_message = await storage.get('welcome_message')
+            welcome_message = welcome_message.replace(
+                "{server}",
+                server.name
+            ).replace(
+                "{user}",
+                member.mention
+            )
             destination = server
+            channel_name = await storage.get('channel_name')
             channel = discord.utils.find(lambda c: c.name == channel_name or
                                          c.id == channel_name,
                                          server.channels)
             if channel is not None:
                 destination = channel
 
-        await self.mee6.send_message(destination, welcome_message)
+            await self.mee6.send_message(destination, welcome_message)
+        
+        # Send Direct Mssage welcome if enabeld
+        dm_welcome_enabled = await storage.get('dm_welcome_enabled') is not None
+        if dm_welcome_enabled:
+            welcome_message = await storage.get('dm_welcome_message')
+            welcome_message = welcome_message.replace(
+                "{server}",
+                server.name
+            ).replace(
+                "{user}",
+                member.mention
+            )
+            await self.mee6.send_message(member, welcome_message)
 
     async def on_member_remove(self, member):
         server = member.server

--- a/website/templates/plugin-welcome.html
+++ b/website/templates/plugin-welcome.html
@@ -10,15 +10,22 @@
 					<form id="welcome" method="POST" action="{{url_for('update_welcome', server_id=server['id'])}}">
 						<div class="form-group">
 							<input name=_csrf_token type=hidden value="{{ csrf }}">
-							<label class="control-label" for="welcome_message">Welcome message</label>
-							<input class="form-control input-lg welcome_message" name="welcome_message" value="{{welcome_message}}" ype="text" id="welcome_message">
-							<div class="checkbox">
-								<label>
-									<input type="checkbox" name="private" {% if private %}checked{% endif %}> Send in Private Message
-								</label>
-							</div>
 							<div class="well well-sm">
 								<strong>Tips: </strong> <i>{user}</i> refers to the new member, <i>{server}</i> to your server name.
+							</div>
+							<label class="control-label" for="server_welcome_message">Server welcome message</label>
+							<input class="form-control input-lg server_welcome_message" name="server_welcome_message" value="{{server_welcome_message}}" ype="text" id="server_welcome_message">
+							<div class="checkbox">
+								<label>
+									<input type="checkbox" name="server_welcome_enabled" {% if server_welcome_enabled %}checked{% endif %}> Server welcome enabled
+								</label>
+							</div>
+							<label class="control-label" for="dm_welcome_message">Direct message welcome</label>
+							<input class="form-control input-lg dm_welcome_message" name="dm_welcome_message" value="{{dm_welcome_message}}" ype="text" id="dm_welcome_message">
+							<div class="checkbox">
+								<label>
+									<input type="checkbox" name="dm_welcome_enabled" {% if dm_welcome_enabled %}checked{% endif %}> Direct Message welcome enabled
+								</label>
 							</div>
 							<label class="control-label" for="gb_message">Good Bye message</label>
 							<input class="form-control input-lg gb_message" name="gb_message" value="{{gb_message}}" ype="text" id="gb_message">
@@ -26,9 +33,6 @@
 								<label>
 									<input type="checkbox" name="gb_enabled" {% if gb_enabled %}checked{% endif %}> Enabled
 								</label>
-							</div>
-							<div class="well well-sm">
-								<strong>Tips: </strong> <i>{user}</i> refers to the leaving member, <i>{server}</i> to your server name.
 							</div>
 							<label class="control-label" for="channel_name">Welcome/Good-Bye channel</label>
 							<select class="input-lg form-control" name="channel">


### PR DESCRIPTION
There are now 2 welcome inputs, one for welcome message in a server channel, and the other for DM.

Backwards compatibility is held except if you had "private" set before, since private is now unused people using it will have to do a manual intervention and set their message in the new direct message welcome field

Having 2 separate messages for people joining is useful because you might want to send a longer information message in a direct message and also send a short message in a server channel notifying people that a new person joined.