### PR TITLE
Fixes bad test case for user avatar image

### DIFF
--- a/website/templates/levels.html
+++ b/website/templates/levels.html
@@ -42,7 +42,7 @@
 									<h3><strong>#{{loop.index}}</strong></h3>
 								</div>
 								<div class="col-md-1 col-sm-1 hidden-xs" style="padding:0">
-									{% if player['avatar']!="None" %}
+									{% if player['avatar'] is not none %}
 										<img src="https://discordapp.com/api/users/{{player['id']}}/avatars/{{player['avatar']}}.jpg" style="width:100%" class="img-circle">
 									{%else%}
 										<img src="{{url_for('static', filename='img/no_logo.png')}}" style="width:100%" class="img-circle">


### PR DESCRIPTION
Check for user avatar was erronously checking a None type against a
"None" string, causing the resulting URL to end up as .../None.jpg
instead of using the default avatar image when no avatar exists for the
user.

I did not test the fully, I only confirmed that each individual part was what I expected it would be in more limited scopes.

Also, tangentially related, discord.py can supply the full avatar URL, which may be safer to use than trying to recreate the URL in the jinja template.
