### PR TITLE
Case insensitive command regex matching

### DIFF
--- a/chat-bot/decorators.py
+++ b/chat-bot/decorators.py
@@ -44,7 +44,7 @@ def command(pattern=None, db_check=False, user_check=None, db_name=None,
         async def wrapper(self, message):
 
             # Is it matching?
-            match = prog.match(message.content)
+            match = prog.match(message.content.lower())
             if not match:
                 return
 


### PR DESCRIPTION
```
!Play
```
Will now trigger the play command, when before it prevented Mee6 from recognizing it