### PR TITLE
added some more to the banned roles tooltip

### DIFF
--- a/website/templates/plugin-levels.html
+++ b/website/templates/plugin-levels.html
@@ -34,7 +34,7 @@
 						<label class="control-label" for="banned_roles">Banned Roles</label>
 						<input type="text" data-role="tagsinput" name="banned_roles" class="banned_roles"/><br />
 						<div class="well well-sm">
-							These roles, don't gain <strong>xp</strong>.
+							These roles, don't gain <strong>xp</strong> and won't be able to use the !rank and !levels commands. <br> Bots do not gain xp by default
 						</div>
 						<script>
 $(function() {


### PR DESCRIPTION
because people add 20 something integrated bots roles..... and then are complaining that there is to much in there to find the correct one to remove